### PR TITLE
atelier 3/auth(fix): utilisation interface repository

### DIFF
--- a/card-auth/src/main/java/cpe/atelier3/auth/domain/auth/AuthenticationService.java
+++ b/card-auth/src/main/java/cpe/atelier3/auth/domain/auth/AuthenticationService.java
@@ -1,5 +1,6 @@
 package cpe.atelier3.auth.domain.auth;
 
+import cpe.atelier3.auth.domain.user.IUserRepository;
 import cpe.atelier3.commons.user.exception.InvalidTokenException;
 import cpe.atelier3.commons.user.exception.IncorrectPasswordException;
 import cpe.atelier3.commons.user.exception.UserDoesNotExistException;
@@ -23,9 +24,9 @@ public class AuthenticationService {
 
     private final JWTGenerator jwtGenerator;
 
-    private final UserRepository userRepository;
+    private final IUserRepository userRepository;
 
-    public AuthenticationService(@Qualifier("default") JWTGenerator jwtGenerator, @Autowired UserRepository userRepository) {
+    public AuthenticationService(@Qualifier("default") JWTGenerator jwtGenerator, @Autowired IUserRepository userRepository) {
         this.jwtGenerator = jwtGenerator;
         this.userRepository = userRepository;
     }


### PR DESCRIPTION
Correction utilisation IUserRepository plutôt que UserRepository afin de pouvoir mocker le repo.